### PR TITLE
Bevy main

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["game-engines"]
 description = "Bevy plugin to help implement loading states"
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy.git" }
+bevy = { git = "https://github.com/bevyengine/bevy.git", default-features = false }
 
 [dev-dependencies]
-bevy = "0.5.0"
+bevy = { git = "https://github.com/bevyengine/bevy.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,7 @@ categories = ["game-engines"]
 description = "Bevy plugin to help implement loading states"
 
 [dependencies]
-bevy = { version = "0.5.0", default-features = false }
+bevy = { git = "https://github.com/bevyengine/bevy.git" }
 
 [dev-dependencies]
 bevy = "0.5.0"
-
-[patch.crates-io]
-bevy = { git = "https://github.com/bevyengine/bevy.git" }


### PR DESCRIPTION
The way the dependencies are currently setup, one cannot use the bevy git version. This way it always tracks bevy_main without resorting to patches (which are ignored for those using it in their repository)